### PR TITLE
fix: change const to var  so it doesn't crash on older browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict';
-const isAbsoluteUrl = require('is-absolute-url');
+var isAbsoluteUrl = require('is-absolute-url');
 
 module.exports = url => !isAbsoluteUrl(url);


### PR DESCRIPTION
On older browser, using `const` cause this error to be thrown
```
Uncaught SyntaxError: Use of const in strict mode.
```

This can be fixed in the user side by transpiling the package, but most people do not transpile the `node_modules` to avoid over-transpiling.